### PR TITLE
Use the official Homebrew bottling process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: brew pr-pull
+on:
+  pull_request_target:
+    types:
+      - labeled
+jobs:
+  pr-pull:
+    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up git
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{ github.token }}
+          branch: main
+
+      - name: Delete branch
+        if: github.event.pull_request.head.repo.fork == false
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: git push --delete origin $BRANCH

--- a/Formula/iamy.rb
+++ b/Formula/iamy.rb
@@ -8,7 +8,7 @@ class Iamy < Formula
 
   bottle do
     root_url "https://github.com/envato/iamy/releases/download/v2.4.4"
-    sha256 cellar: :any_skip_relocation, big_sur: "f89bd6b002969645e1c4b37e5b9994d7add10b1bf946a43a079257dd63ff83df"
+    sha256 cellar: :any_skip_relocation, big_sur:  "f89bd6b002969645e1c4b37e5b9994d7add10b1bf946a43a079257dd63ff83df"
     sha256 cellar: :any_skip_relocation, catalina: "ea7e387dcfe89c8736f5dfeb2e746363672be513183b0197e971805d438fa4be"
   end
 
@@ -16,9 +16,8 @@ class Iamy < Formula
   depends_on "awscli"
 
   def install
-    ENV['CGO_CFLAGS'] = "-mmacosx-version-min=10.15"
-    ENV['CGO_LDFLAGS'] = "-mmacosx-version-min=10.15"
-    system "env"
+    ENV["CGO_CFLAGS"] = "-mmacosx-version-min=10.15"
+    ENV["CGO_LDFLAGS"] = "-mmacosx-version-min=10.15"
     system "go", "build", *std_go_args, "-ldflags",
             "-s -w -X main.Version=v#{version}"
   end

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Homebrew tap for the Envato port of the [IAMy by 99designs](https://github.com/99designs/iamy) too.
 
-
 ## How do I install these formulae?
 
 `brew install envato/envato-iamy/<formula>`
@@ -12,3 +11,10 @@ Or `brew tap envato/envato-iamy` and then `brew install <formula>`.
 ## Documentation
 
 `brew help`, `man brew` or check [Homebrew's documentation](https://docs.brew.sh).
+
+## Updating formulae
+
+1. Open a PR with the update
+2. Ensure the tests pass on the PR
+3. When ready, **don't merge the PR**. Instead, label it with `pr-pull`.
+4. This will trigger the "Publish" workflow, which will automatically merge the updates and close the PR.


### PR DESCRIPTION
Homebrew has a default bottling process, which uses `brew test-bot` to create and upload the compiled bottles.

This has the added advantage of ensuring the bottles are built in exactly the same way as an unbottled build process, and should ensure that bottles are built for all suitable targets.

The `publish.yml` workflow was taken from a repo generated via `brew tap-new`.
