### PR TITLE
Rename iamy -> envato-iamy

### DIFF
--- a/Formula/envato-iamy.rb
+++ b/Formula/envato-iamy.rb
@@ -1,19 +1,15 @@
-class Iamy < Formula
+class EnvatoIamy < Formula
   desc "Envato fork of 99Designs IAMy IAM Object and S3 Bucket Policy Management tool"
   homepage "https://github.com/envato/iamy"
   url "https://github.com/envato/iamy/archive/refs/tags/v3.0.0.tar.gz"
-  version "3.0.0+envato"
+  version "3.0.0"
   sha256 "b8ceb153b3a92eb8e9382c360d9a91e9cfb975090d3ed83b0ba9af9746fea12b"
   license "MIT"
 
-  bottle do
-    root_url "https://github.com/envato/homebrew-envato-iamy/releases/download/iamy-3.0.0+envato"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "606916f8445dd428fb88a81ba7aa0a6153e9a25698a191675b7c449e038d43db"
-    sha256 cellar: :any_skip_relocation, catalina:      "76938fbaa764d38436f1b2c210cf4fac3161ab48df6adab92462c590025d900d"
-  end
-
   depends_on "go" => :build
   depends_on "awscli"
+
+  conflicts_with "iamy", because: "envato-iamy also ships an iamy binary"
 
   def install
     ENV["CGO_CFLAGS"] = "-mmacosx-version-min=10.15"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,0 +1,3 @@
+{
+  "iamy": "envato-iamy"
+}


### PR DESCRIPTION
### Context

`iamy` is the formula name in `homebrew-core`, meaning there's ambiguity whenever commands operate on `iamy`.

According to the Homebrew [docs on taps](https://docs.brew.sh/Taps#formula-with-duplicate-names), ambiguous installs will default to the core formula. I believe this results in a significant issue with `Brewfile`s:

```shell
$ brew install iamy
==> Downloading https://ghcr.io/v2/homebrew/core/iamy/manifests/2.3.2-1
Already downloaded: /Users/liamdawson/Library/Caches/Homebrew/downloads/38c893c6b7133308b45644825b385fa32660ba83932795469a797f57186136f4--iamy-2.3.2-1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/iamy/blobs/sha256:02aa2ecaab3e449d3ca641e88a22dca829a969d6984190146514b807cdf2b3a2
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:02aa2ecaab3e449d3ca641e88a22dca829a969d6984190146514b807cdf2b3a2?se=2021-06-25T05%3A40%3A00Z&sig=PPv9VWE0BtGTnlPpMsF%2BWSA9JE6mQaNSQlwFN6SM298%3D&sp=r&spr=https&sr=b&sv=2019-12-12
######################################################################## 100.0%
==> Pouring iamy--2.3.2.big_sur.bottle.1.tar.gz
🍺  /usr/local/Cellar/iamy/2.3.2: 5 files, 21.1MB

$ echo 'brew "envato/envato-iamy/iamy"' > Brewfile

$ brew bundle
Using envato/envato-iamy/iamy
Homebrew Bundle complete! 1 Brewfile dependency now installed.

$ iamy --version
v2.3.2 # envato-iamy is currently v3.0.0+envato
```

As noted the Homebrew [docs on taps](https://docs.brew.sh/Taps#formula-with-duplicate-names):

> we recommend you give formulae a different name if you want to make them easier to install.

### Changes

- Rename `iamy` to `envato-iamy` (chosen via the name of this homebrew tap)
- Re-version formula from `3.0.0+envato` to `3.0.0` (see notes for existing installs)
- Add formula rename entry

### Effects

#### New installs

Had to compile from scratch, because the bottle is broken by the rename. Otherwise, worked as expected, even with the old formula name:

```shell
$ brew install envato/envato-iamy/iamy
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).
==> Updated Casks
Updated 1 cask.

Warning: Use envato/envato-iamy/envato-iamy instead of deprecated iamy
Warning: Use envato/envato-iamy/envato-iamy instead of deprecated iamy
==> Installing envato-iamy from envato/envato-iamy
==> Downloading https://github.com/envato/iamy/archive/refs/tags/v3.0.0.tar.gz
Already downloaded: /Users/liamdawson/Library/Caches/Homebrew/downloads/40050cedc6716b7bff75c6508a84a6329feb8f7f891baba664b24e30f6f110d5--iamy-3.0.0.tar.gz
==> go build -ldflags -s -w -X main.Version=v3.0.0+envato
🍺  /usr/local/Cellar/envato-iamy/3.0.0+envato: 5 files, 14.4MB, built in 6 seconds
```

#### Existing installs

My very unscientific test suggests that existing installs will correctly upgrade using the new formula thanks to the alias:

```shell
$ pwd
/usr/local/Homebrew/Library/Taps/envato/homebrew-envato-iamy

$ brew install envato/envato-iamy/iamy
==> Installing iamy from envato/envato-iamy
==> Downloading https://github.com/envato/homebrew-envato-iamy/releases/download/iamy-3.0.0+envato/iamy-3.0.0%2Benvato.catalina.bottle.tar.gz
Already downloaded: /Users/liamdawson/Library/Caches/Homebrew/downloads/a539d806a7bce977eeae51f95c7f730f6162b3df243a34dd636b381e295eecfd--iamy-3.0.0+envato.catalina.bottle.tar.gz
==> Pouring iamy-3.0.0+envato.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/iamy/3.0.0+envato: 5 files, 14.4MB

$ git checkout use-namespaced-formula 
Switched to branch 'use-namespaced-formula'

$ brew upgrade
==> Upgrading 1 outdated package:
envato/envato-iamy/envato-iamy 3.0.0
==> Processing iamy formula rename to envato-iamy
==> Unlinking iamy
==> Moving iamy versions to /usr/local/Cellar/envato-iamy
==> Relinking envato-iamy
==> Upgrading envato/envato-iamy/envato-iamy
  3.0.0+envato -> 3.0.0 

==> Downloading https://github.com/envato/iamy/archive/refs/tags/v3.0.0.tar.gz
Already downloaded: /Users/liamdawson/Library/Caches/Homebrew/downloads/40050cedc6716b7bff75c6508a84a6329feb8f7f891baba664b24e30f6f110d5--iamy-3.0.0.tar.gz
==> go build -ldflags -s -w -X main.Version=v3.0.0
🍺  /usr/local/Cellar/envato-iamy/3.0.0: 5 files, 14.4MB, built in 6 seconds
```

Notably, the upgrade failed if the formula version didn't change. If we want to retain the `+envato` in the formula version, we should bundle this change with a version bump.